### PR TITLE
- Fixed bug in latest Webkit versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,4 +30,4 @@ document.body.addEventListener('touchmove', function(evt) {
   if(!evt._isScroller) {
     evt.preventDefault()
   }
-})
+}, {passive: false})


### PR DESCRIPTION
Now it works on them. 
Related with https://github.com/luster-io/prevent-overscroll/issues/4#issuecomment-390108910

See the topic in Webkit issues:
https://bugs.webkit.org/show_bug.cgi?id=182521